### PR TITLE
cambie int por double, excepto en los experiementos para el tp

### DIFF
--- a/tp1/experiments_src/runWithInput.cpp
+++ b/tp1/experiments_src/runWithInput.cpp
@@ -9,24 +9,24 @@
 #include "../scr/brute_force/KnapsackDesitionTree.h"
 #include "../scr/brute_force/BruteForce.h"
 
-int callSolution(std::vector<Request> *elements, int objectiveValue) {
+double callSolution(std::vector<Request> *elements, double objectiveValue) {
     Knapsack* knapsack = new KnapsackDesitionTree(new BruteForce());
-    int response = knapsack->maximumBenefit(objectiveValue,elements);
+    double response = knapsack->maximumBenefit(objectiveValue,elements);
     return response;
 }
 
 int main(){
 
     int sizeOfArray;
-    int objectiveValue;
+    double objectiveValue;
     std::cout << "Pass sets of values and finally 0 0 for expresing end of values." << std::endl;
     std::cin >> sizeOfArray;
     std::cin >> objectiveValue;
     while(sizeOfArray != 0 && objectiveValue != 0){
         std::vector<Request> elements;
         elements.clear();
-        int cost;
-        int benefit;
+        double cost;
+        double benefit;
         for(int index = 0; index < sizeOfArray; index ++){
             std::cin >> cost;
             std::cin >> benefit;

--- a/tp1/experiments_src/run_all_experiments.cpp
+++ b/tp1/experiments_src/run_all_experiments.cpp
@@ -11,11 +11,11 @@
 #include "../scr/meet_in_the_middle/MeetInTheMiddle.h"
 double calcularTiempos(Knapsack *knapsack, int cantidadDeIteraciones, double capacity, std::vector<Request> *requests);
 
-std::vector<Request> crearInstanciaConCostoYBeneficioAleatorio(int elementos, int capacidad);
+std::vector<Request> crearInstanciaConCostoYBeneficioAleatorio(int elementos, double capacidad);
 
-std::vector<Request> crearInstanciaExperimento4(int elementos, int capacidad);
+std::vector<Request> crearInstanciaExperimento4(int elementos, double capacidad);
 
-std::vector<Request> crearInstanciaExperimento5(int elementos, int capacidad);
+std::vector<Request> crearInstanciaExperimento5(int elementos, double capacidad);
 
 int main(){
 
@@ -263,22 +263,22 @@ int main(){
 
 
 
-std::vector<Request> crearInstanciaExperimento5(int cantidadDeElementos, int capacidad) {
+std::vector<Request> crearInstanciaExperimento5(int cantidadDeElementos, double capacidad) {
     std::vector<Request> instancia;
     instancia.reserve(cantidadDeElementos);
     for(int index = 0; index < cantidadDeElementos; index++){
-        instancia.push_back(Request(std::rand() % (capacidad*2) + capacidad+1,std::rand()));
+        instancia.push_back(Request(   std::fmod( (float) std::rand() , (capacidad*2) ) + capacidad+1, (float) std::rand()));
     }
     instancia.at(0) = Request(1, INT_MAX);
     assert(instancia.size() == cantidadDeElementos);
     return instancia;
 }
 
-std::vector<Request> crearInstanciaExperimento4(int cantidadDeElementos, int capacidad) {
+std::vector<Request> crearInstanciaExperimento4(int cantidadDeElementos, double capacidad) {
     std::vector<Request> instancia;
     instancia.reserve(cantidadDeElementos);
     for(int index = 0; index < cantidadDeElementos; index++){
-        instancia.push_back(Request(std::rand() % (capacidad*2) + capacidad+1, std::rand()));
+        instancia.push_back(Request(  std::fmod( (float) std::rand() , (capacidad*2) ) + capacidad+1, (float) std::rand()));
     }
     instancia.at(cantidadDeElementos-1) = Request(0,INT_MAX);
     assert(instancia.size() == cantidadDeElementos);
@@ -288,11 +288,11 @@ std::vector<Request> crearInstanciaExperimento4(int cantidadDeElementos, int cap
 /*
  * Instancia con costo entre 0 y la capacidad, y beneficio aleatorio.
  */
-std::vector<Request> crearInstanciaConCostoYBeneficioAleatorio(int cantidadDeElementos, int capacidad){
+std::vector<Request> crearInstanciaConCostoYBeneficioAleatorio(int cantidadDeElementos, double capacidad){
     std::vector<Request> instancia;
     instancia.reserve(cantidadDeElementos);
     for(int index = 0; index < cantidadDeElementos; index++){
-        instancia.push_back(Request(std::rand() % capacidad,std::rand()));
+        instancia.push_back(   Request(  std::fmod( (float) std::rand() , capacidad )    , (float) std::rand()  )  );
     }
     assert(instancia.size() == cantidadDeElementos);
     return instancia;

--- a/tp1/scr/Knapsack.h
+++ b/tp1/scr/Knapsack.h
@@ -10,7 +10,7 @@
 
 class Knapsack {
 public:
-    virtual int maximumBenefit(double capacity, std::vector<Request> *requests) = 0;
+    virtual double maximumBenefit(double capacity, std::vector<Request> *requests) = 0;
 };
 
 

--- a/tp1/scr/Request.h
+++ b/tp1/scr/Request.h
@@ -8,9 +8,9 @@
 
 class Request {
 public:
-    int cost;
-    int benefit;
-    Request(int cost, int benfit){
+    double cost;
+    double benefit;
+    Request(double cost, double benfit){
         this->cost = cost;
         this->benefit = benfit;
     }

--- a/tp1/scr/Solution.h
+++ b/tp1/scr/Solution.h
@@ -8,10 +8,10 @@
 
 class Solution {
 public:
-    int cost;
-    int benefit;
+    double cost;
+    double benefit;
 
-    Solution(int cost, int benefit) {
+    Solution(double cost, double benefit) {
         this->cost = cost;
         this->benefit = benefit;
     }

--- a/tp1/scr/backtracking/Backtracking.cpp
+++ b/tp1/scr/backtracking/Backtracking.cpp
@@ -9,13 +9,13 @@
 
 bool
 Backtracking::strategyOptimization(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests,
-                                   double capacity, int actualMaximum) {
+                                   double capacity, double actualMaximum) {
     return factabilityCut(requestsIndex, electionTree, requests, capacity) &&
             optimalityCut(requestsIndex, electionTree, requests, actualMaximum);
 }
 
 bool Backtracking::optimalityCut(int requestsIndex, std::vector<int> *electionTree,
-                                 std::vector<Request> *requests, int actualMaximum) {
+                                 std::vector<Request> *requests, double actualMaximum) {
     return sumSelectedRequestsBenefits(requestsIndex, electionTree, requests) +
            sumNextRequestsBenefits(requestsIndex, requests) >= actualMaximum;
 }
@@ -25,8 +25,8 @@ bool Backtracking::factabilityCut(int requestsIndex, std::vector<int> *electionT
     return sumSelectedRequestsCosts(requestsIndex, electionTree, requests) <= capacity;
 }
 
-int Backtracking::sumSelectedRequestsCosts(int index, std::vector<int> *electionTree, std::vector <Request> *requests) {
-    int summatory = 0;
+double Backtracking::sumSelectedRequestsCosts(int index, std::vector<int> *electionTree, std::vector <Request> *requests) {
+    double summatory = 0;
     for(int iterator = 0; iterator < index; iterator++){
         if(electionTree->at(iterator) == SELECTED_BRANCH){
             summatory += requests->at(iterator).cost;
@@ -35,9 +35,9 @@ int Backtracking::sumSelectedRequestsCosts(int index, std::vector<int> *election
     return summatory;
 }
 
-int Backtracking::sumSelectedRequestsBenefits(int requestsIndex, std::vector<int> *electionTree,
+double Backtracking::sumSelectedRequestsBenefits(int requestsIndex, std::vector<int> *electionTree,
                                               std::vector<Request> *requests) {
-    int summatory = 0;
+    double summatory = 0;
     for(int iterator = 0; iterator < requestsIndex; iterator++){
         if(electionTree->at(iterator) == SELECTED_BRANCH){
             summatory += requests->at(iterator).benefit;
@@ -46,8 +46,8 @@ int Backtracking::sumSelectedRequestsBenefits(int requestsIndex, std::vector<int
     return summatory;
 }
 
-int Backtracking::sumNextRequestsBenefits(int requestsIndex, std::vector<Request> *requests) {
-    int summatory = 0;
+double Backtracking::sumNextRequestsBenefits(int requestsIndex, std::vector<Request> *requests) {
+    double summatory = 0;
     for(int iterator = requestsIndex; iterator < requests->size(); iterator++){
         summatory += requests->at(iterator).benefit;
     }

--- a/tp1/scr/backtracking/Backtracking.h
+++ b/tp1/scr/backtracking/Backtracking.h
@@ -12,19 +12,19 @@ class Backtracking : public DesitionTreeStrategy {
 public:
     bool
     strategyOptimization(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests,
-                         double capacity, int actualMaximum) override;
+                         double capacity, double actualMaximum) override;
 
-    int sumSelectedRequestsCosts(int index, std::vector<int> *electionTree, std::vector<Request> *requests);
+    double sumSelectedRequestsCosts(int index, std::vector<int> *electionTree, std::vector<Request> *requests);
 
     bool factabilityCut(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests,
                         double capacity);
 
-    int sumSelectedRequestsBenefits(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests);
+    double sumSelectedRequestsBenefits(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests);
 
-    int sumNextRequestsBenefits(int requestsIndex, std::vector<Request> *requests);
+    double sumNextRequestsBenefits(int requestsIndex, std::vector<Request> *requests);
 
     bool optimalityCut(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests,
-                       int actualMaximum);
+                       double actualMaximum);
 };
 
 

--- a/tp1/scr/brute_force/BruteForce.cpp
+++ b/tp1/scr/brute_force/BruteForce.cpp
@@ -5,6 +5,6 @@
 #include "BruteForce.h"
 
 bool BruteForce::strategyOptimization(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests,
-                                      double capacity, int actualMaximum) {
+                                      double capacity, double actualMaximum) {
     return true;
 }

--- a/tp1/scr/brute_force/BruteForce.h
+++ b/tp1/scr/brute_force/BruteForce.h
@@ -10,7 +10,7 @@
 class BruteForce : public DesitionTreeStrategy{
 public:
     bool strategyOptimization(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests,
-                              double capacity, int actualMaximum) override;
+                              double capacity, double actualMaximum) override;
 };
 
 

--- a/tp1/scr/brute_force/DesitionTreeStrategy.h
+++ b/tp1/scr/brute_force/DesitionTreeStrategy.h
@@ -12,7 +12,7 @@ class DesitionTreeStrategy {
 public:
     virtual bool
     strategyOptimization(int requestsIndex, std::vector<int> *electionTree, std::vector<Request> *requests,
-                         double capacity, int actualMaximum) = 0;
+                         double capacity, double actualMaximum) = 0;
 };
 
 #endif //TP1_MOCHILA_DESITIONTREESTRATEGY_H

--- a/tp1/scr/brute_force/KnapsackDesitionTree.cpp
+++ b/tp1/scr/brute_force/KnapsackDesitionTree.cpp
@@ -14,7 +14,7 @@ KnapsackDesitionTree::KnapsackDesitionTree(DesitionTreeStrategy *pBacktracking) 
     this->strategy = pBacktracking;
 }
 
-int KnapsackDesitionTree::maximumBenefit(double capacity, std::__1::vector<Request> *requests) {
+double KnapsackDesitionTree::maximumBenefit(double capacity, std::__1::vector<Request> *requests) {
     this->requests = requests;
     this->capacity = capacity;
     this->partialMaximum = -1;
@@ -51,8 +51,8 @@ bool KnapsackDesitionTree::isValidActualSolution() {
     return this->sumatoryOfActualSolution() <= this->capacity;
 }
 
-int KnapsackDesitionTree::sumatoryOfActualSolution() {
-    int summatory = 0;
+double KnapsackDesitionTree::sumatoryOfActualSolution() {
+    double summatory = 0;
     for(int iterator = 0; iterator < this->electionTree->size(); iterator++){
         if(this->electionTree->at(iterator) == SELECTED_BRANCH){
             summatory += this->requests->at(iterator).cost;
@@ -61,8 +61,8 @@ int KnapsackDesitionTree::sumatoryOfActualSolution() {
     return summatory;
 }
 
-int KnapsackDesitionTree::sumSelectedRequestsBenefits() {
-    int summatory = 0;
+double KnapsackDesitionTree::sumSelectedRequestsBenefits() {
+    double summatory = 0;
     for(int iterator = 0; iterator < this->electionTree->size(); iterator++){
         if(this->electionTree->at(iterator) == SELECTED_BRANCH){
             summatory += this->requests->at(iterator).benefit;

--- a/tp1/scr/brute_force/KnapsackDesitionTree.h
+++ b/tp1/scr/brute_force/KnapsackDesitionTree.h
@@ -14,7 +14,7 @@
 
 class KnapsackDesitionTree : public Knapsack{
 public:
-    int maximumBenefit(double capacity, std::vector<Request> *requests) override;
+    double maximumBenefit(double capacity, std::vector<Request> *requests) override;
 
     KnapsackDesitionTree(DesitionTreeStrategy *pBacktracking);
 
@@ -23,7 +23,7 @@ public:
 private:
     std::vector<Request> *requests;
     double capacity;
-    int partialMaximum;
+    double partialMaximum;
     std::vector<int> *electionTree;
     DesitionTreeStrategy *strategy;
     std::set<Solution> *solutions;
@@ -32,9 +32,9 @@ private:
 
     bool isValidActualSolution();
 
-    int sumatoryOfActualSolution();
+    double sumatoryOfActualSolution();
 
-    int sumSelectedRequestsBenefits();
+    double sumSelectedRequestsBenefits();
 
     bool isABetterSolution();
 

--- a/tp1/scr/dynamic_programming/DynamicProgrammingAlgorithm.cpp
+++ b/tp1/scr/dynamic_programming/DynamicProgrammingAlgorithm.cpp
@@ -2,10 +2,10 @@
 #include <algorithm>
 
 // inicializa con ceros
-std::vector<std::vector<int> > DynamicProgrammingAlgorithm::inicializarMatriz(int filas,int columnas) {	 // cuesta O(filas.columnas).
-    std::vector<std::vector<int> > matrix;
+std::vector<std::vector<double> > DynamicProgrammingAlgorithm::inicializarMatriz(int filas,int columnas) {	 // cuesta O(filas.columnas).
+    std::vector<std::vector<double> > matrix;
     for(int i = 0; i<filas; i++) {
-        std::vector<int> myvector; // inicializo una fila
+        std::vector<double> myvector; // inicializo una fila
         for(int j = 0; j<columnas; j++) {
             myvector.push_back(0); // seteo el valor '0' en cada posicion [i][j].
         }
@@ -14,11 +14,11 @@ std::vector<std::vector<int> > DynamicProgrammingAlgorithm::inicializarMatriz(in
     return matrix;
 }
 
-int DynamicProgrammingAlgorithm::maximo(int a, int b) {
+double DynamicProgrammingAlgorithm::maximo(double a, double b) {
     return std::max(a,b);
 }
 
-bool DynamicProgrammingAlgorithm::ningunRequestPuedeEntrar(std::vector<Request>* requests,int maxCapacity ) {
+bool DynamicProgrammingAlgorithm::ningunRequestPuedeEntrar(std::vector<Request>* requests,double maxCapacity ) {
     for(int i = (*requests).size()-1; i >= 0; i = i-1) {
         if ((*requests)[i].cost <= maxCapacity  ) {
             return false;
@@ -28,23 +28,23 @@ bool DynamicProgrammingAlgorithm::ningunRequestPuedeEntrar(std::vector<Request>*
 }
 
 
-int DynamicProgrammingAlgorithm::maximumBenefit(int capacity, std::vector<Request>* requests) {
+double DynamicProgrammingAlgorithm::maximumBenefit(double capacity, std::vector<Request>* requests) {
     if(requests->size()==0){
         return -1;
     }
-    std::vector<std::vector<int> >  matrix = inicializarMatriz(requests->size()+1,capacity+1);
+    std::vector<std::vector<double> >  matrix = inicializarMatriz(requests->size()+1,capacity+1);
     // se comienza en la posicion [1][1], ya que la 1er fila y la 1er columna tienen ceros
     int cantFilas = matrix.size();
     int cantCols = matrix[0].size();
     for(int i = 1; i<cantFilas; i++) { // i es el indice de los pedidos
-        int volumenPedidoActual = (*requests)[i-1].cost;
+        double volumenPedidoActual = (*requests)[i-1].cost;
         for(int j = 1; j<cantCols; j++) { // j es la capacidad parcial
 
-            int maxBeneficioSinIncluirPedidoActual = maximo(matrix[i-1][j],matrix[i][j-1]);
+            double maxBeneficioSinIncluirPedidoActual = maximo(matrix[i-1][j],matrix[i][j-1]);
 
             if(j-volumenPedidoActual>=0) {
-                int beneficioPedidoActual = (*requests)[i-1].benefit;
-                int maxBeneficioIncluyendoPedidoActual = beneficioPedidoActual + matrix[i-1][j-volumenPedidoActual];
+                double beneficioPedidoActual = (*requests)[i-1].benefit;
+                double maxBeneficioIncluyendoPedidoActual = beneficioPedidoActual + matrix[i-1][j-volumenPedidoActual];
                 matrix[i][j] = maximo(maxBeneficioSinIncluirPedidoActual,maxBeneficioIncluyendoPedidoActual);
             }
             else {

--- a/tp1/scr/dynamic_programming/DynamicProgrammingAlgorithm.h
+++ b/tp1/scr/dynamic_programming/DynamicProgrammingAlgorithm.h
@@ -7,13 +7,13 @@ class DynamicProgrammingAlgorithm  : public Knapsack {
 
 public:
 
-    int maximumBenefit(int capacity, std::vector <Request> *requests) override ;
+    double maximumBenefit(double capacity, std::vector <Request> *requests) override ;
 
 //protected: // (is all public for testing)
 
-    std::vector<std::vector<int> > inicializarMatriz(int filas,int columnas);
-    int maximo(int a, int b);
-    bool ningunRequestPuedeEntrar(std::vector<Request>* requests,int maxCapacity );
+    std::vector<std::vector<double> > inicializarMatriz(int filas,int columnas);
+    double maximo(double a, double b);
+    bool ningunRequestPuedeEntrar(std::vector<Request>* requests,double maxCapacity );
 };
 
 #endif //TP1_MOCHILA_DYNAMICPROGRAMMINGALGORITHM_H

--- a/tp1/scr/meet_in_the_middle/MeetInTheMiddle.cpp
+++ b/tp1/scr/meet_in_the_middle/MeetInTheMiddle.cpp
@@ -8,7 +8,7 @@
 #include "../Solution.h"
 #include <algorithm>
 
-int MeetInTheMiddle::maximumBenefit(double capacity, std::vector<Request> *requests) {
+double MeetInTheMiddle::maximumBenefit(double capacity, std::vector<Request> *requests) {
     KnapsackDesitionTree *bruteForce = new KnapsackDesitionTree(new BruteForce());
     std::vector<Request>::iterator last = requests->begin() + (requests->size()/2);
 
@@ -26,16 +26,16 @@ int MeetInTheMiddle::maximumBenefit(double capacity, std::vector<Request> *reque
     return mergeSolutions(&firstHalfSolutions,&secondHalfSolutions, capacity);
 }
 
-int MeetInTheMiddle::mergeSolutions(std::vector<Solution> *firstHalfSolutions,
+double MeetInTheMiddle::mergeSolutions(std::vector<Solution> *firstHalfSolutions,
                                     std::vector<Solution> *secondHalfSolutions,
                                     double capacity) {
     std::sort(firstHalfSolutions->begin(),firstHalfSolutions->end(), solutionCompare);
     std::sort(secondHalfSolutions->begin(),secondHalfSolutions->end(), solutionCompare);
 
     bool search = true;
-    unsigned long firstHalfIndex = 0;
-    unsigned long secondHalfIndex = secondHalfSolutions->size()-1;
-    int bestBenefit = -1;
+    double firstHalfIndex = 0;
+    double secondHalfIndex = secondHalfSolutions->size()-1;
+    double bestBenefit = -1;
     while(search){
         if(firstHalfIndex == firstHalfSolutions->size() || secondHalfIndex == -1){
             search = false;

--- a/tp1/scr/meet_in_the_middle/MeetInTheMiddle.h
+++ b/tp1/scr/meet_in_the_middle/MeetInTheMiddle.h
@@ -11,9 +11,9 @@
 
 class MeetInTheMiddle : public Knapsack{
 public:
-    int maximumBenefit(double capacity, std::vector<Request> *requests) override ;
+    double maximumBenefit(double capacity, std::vector<Request> *requests) override ;
 
-    int mergeSolutions(std::vector<Solution> *firstHalfSolutions, std::vector<Solution> *secondHalfSolutions,
+    double mergeSolutions(std::vector<Solution> *firstHalfSolutions, std::vector<Solution> *secondHalfSolutions,
                        double capacity);
 };
 

--- a/tp1/test/BacktrackingTest.cpp
+++ b/tp1/test/BacktrackingTest.cpp
@@ -26,7 +26,7 @@ struct BacktrackingTest : testing::Test{
 };
 
 TEST_F(BacktrackingTest, whenABackpackIsValidToContinue_mustReturnTrue){
-    int capacity = 15;
+    double capacity = 15;
     std::vector<int> electionTree{SELECTED_BRANCH,SELECTED_BRANCH};
     int requestsIndex = 2;
 
@@ -36,7 +36,7 @@ TEST_F(BacktrackingTest, whenABackpackIsValidToContinue_mustReturnTrue){
 }
 
 TEST_F(BacktrackingTest, whenABackpackHasAHigherCostThanItsCapacity_mustReturnFalse){
-    int capacity = 9;
+    double capacity = 9;
     std::vector<int> electionTree{SELECTED_BRANCH,SELECTED_BRANCH};
     int requestsIndex = 2;
 
@@ -48,7 +48,7 @@ TEST_F(BacktrackingTest, whenABackpackHasAHigherCostThanItsCapacity_mustReturnFa
 TEST_F(BacktrackingTest, whenAKnapbackMayImproveAPartialMaximum_mustReturnTrue){
     std::vector<int> electionTree{NO_SELECTED_BRANCH,SELECTED_BRANCH};
     int requestsIndex = 2;
-    int actualMaximum = 12 + 13 + 20;
+    double actualMaximum = 12 + 13 + 20;
 
     bool actualResponce = backtracking->strategyOptimization(requestsIndex, &electionTree, &requests1, 100, actualMaximum);
 
@@ -58,7 +58,7 @@ TEST_F(BacktrackingTest, whenAKnapbackMayImproveAPartialMaximum_mustReturnTrue){
 TEST_F(BacktrackingTest, whenAKnapbackCantImproveAPartialMaximum_mustReturnFalse){
     std::vector<int> electionTree{SELECTED_BRANCH,NO_SELECTED_BRANCH};
     int requestsIndex = 2;
-    int actualMaximum = 15 + 13 + 20;
+    double actualMaximum = 15 + 13 + 20;
 
     bool actualResponce = backtracking->strategyOptimization(requestsIndex, &electionTree, &requests1, 100, actualMaximum);
 

--- a/tp1/test/DynamicProgrammingAlgorithmTest.cpp
+++ b/tp1/test/DynamicProgrammingAlgorithmTest.cpp
@@ -15,9 +15,9 @@ struct DynamicProgrammingAlgorithmTest : testing::Test{
 
 TEST_F(DynamicProgrammingAlgorithmTest, maximoTest){
 
-    int a = 2;
-    int b = 1;
-    int result = dynamicProgrammingAlgorithm->maximo(a,b);
+    double a = 2;
+    double b = 1;
+    double result = dynamicProgrammingAlgorithm->maximo(a,b);
     ASSERT_EQ(2, result);
 
     a = 2;
@@ -32,7 +32,7 @@ TEST_F(DynamicProgrammingAlgorithmTest, maximoTest){
 }
 
 TEST_F(DynamicProgrammingAlgorithmTest, iniciarMatriz) {
-    std::vector<std::vector<int> > matrix = dynamicProgrammingAlgorithm->inicializarMatriz(10, 6);
+    std::vector<std::vector<double> > matrix = dynamicProgrammingAlgorithm->inicializarMatriz(10, 6);
     bool result = true;
 
     int cantFilas = matrix.size();
@@ -48,7 +48,7 @@ TEST_F(DynamicProgrammingAlgorithmTest, iniciarMatriz) {
 }
 
 TEST_F(DynamicProgrammingAlgorithmTest, iniciarMatrizFalseValorModificado) {
-    std::vector<std::vector<int> > matrix = dynamicProgrammingAlgorithm->inicializarMatriz(10, 6);
+    std::vector<std::vector<double> > matrix = dynamicProgrammingAlgorithm->inicializarMatriz(10, 6);
     matrix[5][4] = 1;
 
     bool result = true;
@@ -67,7 +67,7 @@ TEST_F(DynamicProgrammingAlgorithmTest, iniciarMatrizFalseValorModificado) {
 
 TEST_F(DynamicProgrammingAlgorithmTest, requestMayorACapacidad) {
 
-    int capacity = 3;
+    double capacity = 3;
     std::vector<Request> requests;
     requests.push_back(Request(6,12));
     requests.push_back(Request(4,15));
@@ -80,7 +80,7 @@ TEST_F(DynamicProgrammingAlgorithmTest, requestMayorACapacidad) {
 
 TEST_F(DynamicProgrammingAlgorithmTest, requestMenorACapacidad) {
 
-    int capacity = 8;
+    double capacity = 8;
     std::vector<Request> requests;
     requests.push_back(Request(6,12));
     requests.push_back(Request(4,15));

--- a/tp1/test/KnapbackTest.cpp
+++ b/tp1/test/KnapbackTest.cpp
@@ -27,57 +27,57 @@ struct KnapbackTest : testing::Test{
 };
 
 TEST_F(KnapbackTest, whenHaveOnlyOneRequest_mustReturnItsBenefit){
-    int capacity = 10;
+    double capacity = 10;
     std::vector<Request> requests;
-    int cost = 5;
-    int benefit = 15;
+    double cost = 5;
+    double benefit = 15;
     requests.push_back(Request(cost, benefit));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(benefit, actualBenefit);
 }
 
 TEST_F(KnapbackTest, whenCostIsBiggerThanCapacity_mustNotSaveSolution){
-    int capacity = 10;
+    double capacity = 10;
     std::vector<Request> requests;
-    int cost = 50;
-    int benefit = 15;
+    double cost = 50;
+    double benefit = 15;
     requests.push_back(Request(cost, benefit));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(-1, actualBenefit);
 }
 
 TEST_F(KnapbackTest, whenHaveMultipleRequest_mustGiveCorrectBenefit){
-    int capacity = 10;
+    double capacity = 10;
     std::vector<Request> requests;
     requests.push_back(Request(6,12));
     requests.push_back(Request(4,15));
     requests.push_back(Request(3,13));
     requests.push_back(Request(7,20));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(33, actualBenefit);
 }
 
 TEST_F(KnapbackTest, whenDoesNotExistSolution_mustReturnZero){
-    int capacity = 2;
+    double capacity = 2;
     std::vector<Request> requests;
     requests.push_back(Request(6,12));
     requests.push_back(Request(4,15));
     requests.push_back(Request(3,13));
     requests.push_back(Request(7,20));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(-1, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testingScenario_01){
-    int capacity = 25;
+    double capacity = 25;
     std::vector<Request> requests;
     requests.push_back(Request(10,5));
     requests.push_back(Request(15,4));
@@ -85,22 +85,22 @@ TEST_F(KnapbackTest, testingScenario_01){
     requests.push_back(Request(10,8));
     requests.push_back(Request(5,8));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(29, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testWithoutRequest) {
-    int capacity = 25;
+    double capacity = 25;
     std::vector<Request> requests;
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(-1, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testCapacityZero) {
-    int capacity = 0;
+    double capacity = 0;
     std::vector<Request> requests;
     requests.push_back(Request(10,5));
     requests.push_back(Request(15,4));
@@ -108,14 +108,14 @@ TEST_F(KnapbackTest, testCapacityZero) {
     requests.push_back(Request(10,8));
     requests.push_back(Request(5,8));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(-1, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testBasicRequest) {
 
-    int capacity = 9;
+    double capacity = 9;
     std::vector<Request> requests;
 
     requests.push_back(Request(2,5));
@@ -123,14 +123,14 @@ TEST_F(KnapbackTest, testBasicRequest) {
     requests.push_back(Request(7,2));
     requests.push_back(Request(1,4));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(16, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testSameValuesBenefitAndCost_1) {
 
-    int capacity = 1;
+    double capacity = 1;
     std::vector<Request> requests;
 
     requests.push_back(Request(1,1));
@@ -139,14 +139,14 @@ TEST_F(KnapbackTest, testSameValuesBenefitAndCost_1) {
     requests.push_back(Request(4,4));
     requests.push_back(Request(5,5));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(1, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testSameValuesBenefitAndCost_2) {
 
-    int capacity = 2;
+    double capacity = 2;
     std::vector<Request> requests;
 
     requests.push_back(Request(1,1));
@@ -155,14 +155,14 @@ TEST_F(KnapbackTest, testSameValuesBenefitAndCost_2) {
     requests.push_back(Request(4,4));
     requests.push_back(Request(5,5));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(2, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testSameValuesBenefitAndCost_3) {
 
-    int capacity = 3;
+    double capacity = 3;
     std::vector<Request> requests;
 
     requests.push_back(Request(1,1));
@@ -171,14 +171,14 @@ TEST_F(KnapbackTest, testSameValuesBenefitAndCost_3) {
     requests.push_back(Request(4,4));
     requests.push_back(Request(5,5));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(3, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testSameValuesBenefitAndCost_4) {
 
-    int capacity = 4;
+    double capacity = 4;
     std::vector<Request> requests;
 
     requests.push_back(Request(1,1));
@@ -187,14 +187,14 @@ TEST_F(KnapbackTest, testSameValuesBenefitAndCost_4) {
     requests.push_back(Request(4,4));
     requests.push_back(Request(5,5));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(4, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testSameValuesBenefitAndCost_5) {
 
-    int capacity = 5;
+    double capacity = 5;
     std::vector<Request> requests;
 
     requests.push_back(Request(1,1));
@@ -203,14 +203,14 @@ TEST_F(KnapbackTest, testSameValuesBenefitAndCost_5) {
     requests.push_back(Request(4,4));
     requests.push_back(Request(5,5));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(5, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testSameValuesBenefitAndCost_all_request_solution_15) {
 
-    int capacity = 15;
+    double capacity = 15;
     std::vector<Request> requests;
 
     requests.push_back(Request(1,1));
@@ -219,14 +219,14 @@ TEST_F(KnapbackTest, testSameValuesBenefitAndCost_all_request_solution_15) {
     requests.push_back(Request(4,4));
     requests.push_back(Request(5,5));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(15, actualBenefit);
 }
 
 TEST_F(KnapbackTest, testSameValuesBenefitAndCost_all_request_solution_anything_solution_is_equal_capacity) {
 
-    int capacity = 9;
+    double capacity = 9;
     std::vector<Request> requests;
 
     requests.push_back(Request(1,1));
@@ -235,7 +235,7 @@ TEST_F(KnapbackTest, testSameValuesBenefitAndCost_all_request_solution_anything_
     requests.push_back(Request(4,4));
     requests.push_back(Request(5,5));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(capacity, actualBenefit);
 }
@@ -246,8 +246,8 @@ TEST_F(KnapbackTest, several_solutions) {
     requests.push_back(Request(5,5)); // same, middle values
     requests.push_back(Request(1,10)); // highest benefit and lower cost
 
-    int capacity = 0;
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double capacity = 0;
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
     ASSERT_EQ(-1, actualBenefit);
 
     capacity = 1;
@@ -291,8 +291,8 @@ TEST_F(KnapbackTest, test_same_benefint) {
     requests.push_back(Request(2,3));
     requests.push_back(Request(3,3));
 
-    int capacity = 1;
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double capacity = 1;
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
     ASSERT_EQ(3, actualBenefit);
 
     capacity = 2;
@@ -328,8 +328,8 @@ TEST_F(KnapbackTest, test_same_cost) {
     requests.push_back(Request(1,2));
     requests.push_back(Request(1,3));
 
-    int capacity = 1;
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double capacity = 1;
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
     ASSERT_EQ(3, actualBenefit);
 
     capacity = 2;
@@ -355,8 +355,8 @@ TEST_F(KnapbackTest, test_all_combinations_were_solutions) {
     requests.push_back(Request(3,4));
     requests.push_back(Request(6,100));
 
-    int capacity = 0;
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double capacity = 0;
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
     ASSERT_EQ(-1, actualBenefit);
 
     capacity = 1;
@@ -412,28 +412,28 @@ TEST_F(KnapbackTest, test_all_combinations_were_solutions) {
 
 TEST_F(KnapbackTest, test_middle_is_best_solution) {
 
-    int capacity = 4;
+    double capacity = 4;
     std::vector<Request> requests;
 
     requests.push_back(Request(4,100));
     requests.push_back(Request(1,100));
     requests.push_back(Request(5,3));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
 
     ASSERT_EQ(100, actualBenefit);
 }
 
 TEST_F(KnapbackTest, test_first_and_then_last_is_best_solution) {
 
-    int capacity = 4;
+    double capacity = 4;
     std::vector<Request> requests;
 
     requests.push_back(Request(1,100));
     requests.push_back(Request(4,99));
     requests.push_back(Request(1,98));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
     ASSERT_EQ(198, actualBenefit);
 
     capacity = 2;
@@ -443,13 +443,13 @@ TEST_F(KnapbackTest, test_first_and_then_last_is_best_solution) {
 
 TEST_F(KnapbackTest, test_last_is_best_solution) {
 
-    int capacity = 3;
+    double capacity = 3;
     std::vector<Request> requests;
 
     requests.push_back(Request(3,100));
     requests.push_back(Request(4,99));
     requests.push_back(Request(1,200));
 
-    int actualBenefit = knapsack->maximumBenefit(capacity,&requests);
+    double actualBenefit = knapsack->maximumBenefit(capacity,&requests);
     ASSERT_EQ(200, actualBenefit);
 }

--- a/tp1/test/MeetInTheMiddleTest.cpp
+++ b/tp1/test/MeetInTheMiddleTest.cpp
@@ -97,9 +97,9 @@ TEST_F(MeetTest, mergeTest1){
     second.push_back(Solution(5,6));
     second.push_back(Solution(1,7));
 
-    int capacity = 2;
+    double capacity = 2;
 
-    int actualBenefit = meet->mergeSolutions(&first, &second, capacity);
+    double actualBenefit = meet->mergeSolutions(&first, &second, capacity);
 
     ASSERT_EQ(14, actualBenefit);
 }
@@ -115,9 +115,9 @@ TEST_F(MeetTest, mergeTest2){
     second.push_back(Solution(5,6));
     second.push_back(Solution(1,7));
 
-    int capacity = 30;
+    double capacity = 30;
 
-    int actualBenefit = meet->mergeSolutions(&first, &second, capacity);
+    double actualBenefit = meet->mergeSolutions(&first, &second, capacity);
 
     ASSERT_EQ(20, actualBenefit);
 }


### PR DESCRIPTION
### Descripción:
Cambie los int por float en valores de capacidad y beneficio
y deje int para indices

### otra cosa fue modificar la funcion modulo 
**(float) std::rand()** : parsear el random a float
**std::fmod( a , b )**  : en lugar de usar % usamos fmod, es la funcion modulo, pero para double en lugar de % que es para enteros.

**como quedarn los metodos que usaban numeros double:**
instancia.push_back(   Request(  std::fmod( (float) std::rand() , capacidad )    , (float) std::rand()  )  );

**convertir random entero en float**
https://stackoverflow.com/questions/5289613/generate-random-float-between-two-floats/5289624

**modulo:**
https://en.cppreference.com/w/cpp/numeric/math/fmod
https://stackoverflow.com/questions/9138790/cant-use-modulus-on-doubles